### PR TITLE
fix: 修复 WebUI 保存配置后被重置的问题

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -35,6 +35,18 @@
     "default": "{at_user} 你还未完成验证。请在 {timeout} 分钟内输入验证码以完成验证",
     "hint": "用户入群未验证时发送消息撤回提示。可用变量: {at_user}, {timeout} (分钟)。"
   },
+  "recall_unverified_messages": {
+    "description": "是否撤回未验证用户的非验证码消息",
+    "type": "bool",
+    "default": false,
+    "hint": "如果启用，将撤回未验证用户发送的非验证码消息。默认关闭。"
+  },
+  "prompt_unverified_user": {
+    "description": "是否提示用户完成验证",
+    "type": "bool",
+    "default": true,
+    "hint": "如果启用，用户未验证时发送消息将提醒用户完成验证，不增加验证错误计数；如果关闭，用户未验证时发送消息将增加验证错误计数，达到一定次数将被踢出群。默认开启。"
+  },
   "failure_message": {
     "description": "验证超时提示语",
     "type": "string",

--- a/main.py
+++ b/main.py
@@ -68,22 +68,18 @@ class GroupGeetestVerifyPlugin(Star):
             self.verify_delay = schema_defaults.get("verify_delay", 3)
             self.group_configs = []
 
+    def _sync_config_from_instance(self):
+        """从实例变量同步配置到配置字典（仅同步 group_configs）"""
+        try:
+            # 只同步 group_configs，根级配置由 AstrBot WebUI 管理
+            self.config["group_configs"] = self.group_configs
+        except Exception as e:
+            logger.error(f"[Geetest Verify] 同步配置失败: {e}")
+
     def _save_config(self):
         """保存配置到磁盘"""
         try:
-            # 更新配置字典
-            self.config["verification_timeout"] = self.verification_timeout
-            self.config["kick_delay"] = self.kick_delay
-            self.config["max_wrong_answers"] = self.max_wrong_answers
-            self.config["api_base_url"] = self.api_base_url
-            self.config["api_key"] = self.api_key
-            self.config["enable_geetest_verify"] = self.enable_geetest_verify
-            self.config["enable_level_verify"] = self.enable_level_verify
-            self.config["min_qq_level"] = self.min_qq_level
-            self.config["verify_delay"] = self.verify_delay
-            self.config["error_verification"] = self.error_verification
-            self.config["recall_unverified_messages"] = self.recall_unverified_messages
-            self.config["prompt_unverified_user"] = self.prompt_unverified_user
+            # 只保存 group_configs，根级配置由 AstrBot WebUI 管理
             self.config["group_configs"] = self.group_configs
             # 保存到磁盘
             self.config.save_config()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: astrbot_plugin_group_geetest_verfy # 插件唯一识别名，以 astrbot_plugin_ 前缀开头
+name: astrbot_plugin_group_geetest_verify # 插件唯一识别名，以 astrbot_plugin_ 前缀开头
 display_name: 入群网页验证插件 # 用于展示的名字，可以是方便人类阅读的名字
 desc: QQ群群聊入群网页验证插件，使用极验Geetest V4实现入群人机验证。 # 插件简短描述
 version: v1.2.3 # 插件版本号。


### PR DESCRIPTION
## Summary
- 修复了在 WebUI 编辑并保存配置后，配置被重置的问题
- 添加了 `_conf_schema.json` 根级别缺失的配置字段
- 修复了 `metadata.yaml` 中插件名称的拼写错误
- 修复了 `_save_config()` 方法覆盖 WebUI 配置的问题

## 问题原因

1. `recall_unverified_messages` 和 `prompt_unverified_user` 在 `main.py` 中作为根级配置使用，但未在 `_conf_schema.json` 根级别定义，导致 AstrBot 配置完整性检查时被移除

2. `_save_config()` 方法会将所有实例变量写回配置字典，当 WebUI 保存新配置后，插件实例变量未更新，导致保存时覆盖了 WebUI 的更改

## Changes

### `_conf_schema.json`
- 添加 `recall_unverified_messages` 根级配置字段
- 添加 `prompt_unverified_user` 根级配置字段

### `metadata.yaml`
- 修复插件名称拼写错误: `verfy` → `verify`

### `main.py`
- 修改 `_save_config()` 方法，只保存 `group_configs`
- 根级配置由 AstrBot WebUI 管理，不再由插件覆盖

## Test plan
- [ ] 在 AstrBot WebUI 中修改根级配置（如 `verification_timeout`、`recall_unverified_messages` 等）
- [ ] 保存配置后刷新页面，确认配置值已保存
- [ ] 使用命令修改群级别配置（如 `/开启验证`），确认配置正常保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)